### PR TITLE
Add Metaname domain registration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,21 @@
+# AGENTS.md
+
+## Purpose
+This file defines tasks, responsibilities, and guidance for AI agents and contributors working on this repository.
+
+## TODOs for Codex or other AI agents
+
+- [ ] Refactor the `MetanameClient` class:
+  - Move the `use_test_api` parameter from the `register_domain()` method into the `__init__()` constructor.
+  - Store the base API URL in `self.api_url`.
+  - Ensure all methods (e.g. `register_domain()`, `check_domain_availability()`) use `self.api_url`.
+
+## Notes
+
+- The current branch implementing domain registration is `codex/add-test-domain-registration-feature`.
+- The test `test_register_domain_with_real_api()` should remain compatible and use `use_test_api=True` during client initialization.
+- See the GitHub PR comment for additional context and rationale for this change.
+
+## Style Guidance
+- Keep method signatures clean — avoid repeating config flags if they apply globally.
+- Follow existing docstring style in `api.py`.

--- a/examples/register_domain.py
+++ b/examples/register_domain.py
@@ -1,0 +1,31 @@
+"""Example: Register a domain using the Metaname test API."""
+
+from metaname_smunz import (
+    ContactDetails,
+    MetanameClient,
+    PhoneNumber,
+    PostalAddress,
+)
+
+client = MetanameClient()
+
+base_contact = ContactDetails(
+    name="Meta Test",
+    email_address="test@example.com",
+    organisation_name=None,
+    postal_address=PostalAddress(
+        line1="123 Test Street",
+        line2=None,
+        city="Wellington",
+        region=None,
+        postal_code="6011",
+        country_code="NZ",
+    ),
+    phone_number=PhoneNumber(country_code="64", area_code="21", local_number="2345678"),
+)
+
+contacts = {"registrant": base_contact, "admin": base_contact, "technical": base_contact}
+
+result = client.register_domain("example-test.nz", 12, contacts)
+print(result)
+

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 pytest
 ruff
+requests

--- a/src/metaname_smunz/__init__.py
+++ b/src/metaname_smunz/__init__.py
@@ -1,0 +1,7 @@
+"""Public package exports."""
+
+from .api import MetanameClient
+from .models import ContactDetails, PhoneNumber, PostalAddress
+
+__all__ = ["MetanameClient", "ContactDetails", "PhoneNumber", "PostalAddress"]
+

--- a/src/metaname_smunz/api.py
+++ b/src/metaname_smunz/api.py
@@ -1,12 +1,44 @@
 # src/metaname_smunz/api.py
 
+import os
+from typing import Dict, Optional
+
 import requests
+
 from .secrets import fetch_op_field
+from .models import ContactDetails
 
 class MetanameClient:
-    def __init__(self, item_name: str = "Metaname API Key", vault_name: str = "startmeup.nz"):
-        self.account_reference = fetch_op_field(item_name, "account_reference", vault_name)
-        self.api_key = fetch_op_field(item_name, "credential", vault_name)
+    """Simple client for interacting with the Metaname API."""
+
+    def __init__(
+        self,
+        account_reference: Optional[str] = None,
+        api_key: Optional[str] = None,
+        item_name: str = "Metaname API Key",
+        vault_name: str = "startmeup.nz",
+    ) -> None:
+        """Initialise the client.
+
+        Credentials can be supplied directly, via environment variables
+        ``METANAME_ACCOUNT_REFERENCE`` and ``METANAME_API_KEY``, or loaded from
+        1Password using ``item_name`` and ``vault_name``.
+        """
+
+        if account_reference is None:
+            account_reference = os.getenv("METANAME_ACCOUNT_REFERENCE")
+        if api_key is None:
+            api_key = os.getenv("METANAME_API_KEY")
+
+        if account_reference is None or api_key is None:
+            self.account_reference = fetch_op_field(
+                item_name, "account_reference", vault_name
+            )
+            self.api_key = fetch_op_field(item_name, "credential", vault_name)
+        else:
+            self.account_reference = account_reference
+            self.api_key = api_key
+
         self.source_ip = self.get_source_ip()
 
     def get_source_ip(self) -> str:
@@ -28,3 +60,41 @@ class MetanameClient:
             return response.json()
         except Exception as e:
             raise RuntimeError(f"Failed to reach Metaname API or parse response: {e}")
+
+    def register_domain(
+        self,
+        domain: str,
+        term: int,
+        contacts: Dict[str, ContactDetails],
+        name_servers: Optional[Dict[str, str]] = None,
+        use_test_api: bool = True,
+    ) -> dict:
+        """Register a domain name using the Metaname API."""
+
+        payload = {
+            "jsonrpc": "2.0",
+            "method": "register_domain_name",
+            "params": [
+                self.account_reference,
+                self.api_key,
+                domain,
+                term,
+                {k: v.to_dict() for k, v in contacts.items()},
+                name_servers,
+            ],
+            "id": 3,
+        }
+
+        url = (
+            "https://test.metaname.net/api/1.1"
+            if use_test_api
+            else "https://metaname.net/api/1.1"
+        )
+
+        try:
+            response = requests.post(url, json=payload)
+            response.raise_for_status()
+            return response.json()
+        except Exception as e:
+            raise RuntimeError(f"Failed to reach Metaname API or parse response: {e}")
+

--- a/src/metaname_smunz/models.py
+++ b/src/metaname_smunz/models.py
@@ -1,0 +1,40 @@
+from dataclasses import asdict, dataclass
+from typing import Optional
+
+
+@dataclass
+class PostalAddress:
+    line1: str
+    line2: Optional[str]
+    city: str
+    region: Optional[str]
+    postal_code: str
+    country_code: str
+
+
+@dataclass
+class PhoneNumber:
+    country_code: str
+    area_code: str
+    local_number: str
+
+
+@dataclass
+class ContactDetails:
+    name: str
+    email_address: str
+    organisation_name: Optional[str]
+    postal_address: PostalAddress
+    phone_number: PhoneNumber
+    fax_number: Optional[str] = None
+
+    def to_dict(self) -> dict:
+        return {
+            "name": self.name,
+            "email_address": self.email_address,
+            "organisation_name": self.organisation_name,
+            "postal_address": asdict(self.postal_address),
+            "phone_number": asdict(self.phone_number),
+            "fax_number": self.fax_number,
+        }
+

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,4 +1,5 @@
 from metaname_smunz.api import MetanameClient
+from metaname_smunz.models import ContactDetails, PhoneNumber, PostalAddress
 
 def test_class_instantiation(monkeypatch):
     def fake_fetch_op_field(item, field, vault):
@@ -45,3 +46,57 @@ def test_check_domain_availability(monkeypatch):
     client = MetanameClient()
     result = client.check_domain_availability("example.nz")
     assert result == {"result": "available"}
+
+
+def test_register_domain(monkeypatch):
+    def fake_fetch_op_field(item, field, vault):
+        return "fake-value"
+
+    def fake_get(url):
+        class FakeResponse:
+            text = "1.2.3.4"
+
+        return FakeResponse()
+
+    def fake_post(url, json):
+        assert url == "https://test.metaname.net/api/1.1"
+        assert json["method"] == "register_domain_name"
+        assert json["params"][2] == "example.nz"
+        assert json["params"][3] == 12
+        class FakeResponse:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {"result": "registered"}
+
+        return FakeResponse()
+
+    monkeypatch.setattr("metaname_smunz.api.fetch_op_field", fake_fetch_op_field)
+    monkeypatch.setattr("metaname_smunz.api.requests.get", fake_get)
+    monkeypatch.setattr("metaname_smunz.api.requests.post", fake_post)
+
+    client = MetanameClient()
+
+    address = PostalAddress(
+        line1="123 Test Street",
+        line2=None,
+        city="Wellington",
+        region=None,
+        postal_code="6011",
+        country_code="NZ",
+    )
+    phone = PhoneNumber(country_code="64", area_code="21", local_number="2345678")
+    contact = ContactDetails(
+        name="Meta Test",
+        email_address="test@example.com",
+        organisation_name=None,
+        postal_address=address,
+        phone_number=phone,
+    )
+
+    contacts = {"registrant": contact, "admin": contact, "technical": contact}
+
+    result = client.register_domain("example.nz", 12, contacts)
+    assert result == {"result": "registered"}
+


### PR DESCRIPTION
## Summary
- allow credentials via env vars or 1Password
- add dataclasses to represent contact details
- implement `register_domain` in `MetanameClient`
- expose classes from package `__init__`
- provide example usage script
- test the new API method

## Testing
- `ruff check src/ tests/ examples/`
- `PYTHONPATH=$(pwd)/src pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_b_6879d13aa854832cb2a70ec604c257f7